### PR TITLE
Fix JSON parsing error in Chinese localization

### DIFF
--- a/common/src/main/resources/assets/clientsort/lang/zh_cn.json
+++ b/common/src/main/resources/assets/clientsort/lang/zh_cn.json
@@ -109,7 +109,7 @@
   "option.clientsort.alwaysMatchByType.tooltip": "物品匹配操作将始终匹配相同类型的物品。",
   "option.clientsort.typeMatchTags": "类型匹配标签",
   "option.clientsort.typeMatchTags.tooltip.1": "具有此列表中任何标签的物品将仅按类型匹配。",
-  "option.clientsort.typeMatchTags.tooltip.2": "仅在"始终按类型匹配"禁用时使用。",
+  "option.clientsort.typeMatchTags.tooltip.2": "仅在「始终按类型匹配」禁用时使用。",
   "option.clientsort.typeMatchTags.tooltip.3": "有关标签列表，请参见 %s。",
 
   "option.clientsort.sounds": "音效",


### PR DESCRIPTION
I sincerely apologize for an error I introduced in my previous translation pull request.

I discovered that in the Chinese language file (`zh_cn.json`), the line:
`"option.clientsort.typeMatchTags.tooltip.2": "仅在"始终按类型匹配"禁用时使用。"`

contains half-width quotation marks within the string value, which creates invalid JSON syntax and causes parsing errors.

This PR fixes the issue by replacing the problematic half-width quotes with full-width Chinese quotation marks:
`"option.clientsort.typeMatchTags.tooltip.2": "仅在「始终按类型匹配」禁用时使用。"`

I'm very sorry that this error made it into the released version. I should have been more careful in validating the JSON format before submitting the original PR. This correction will resolve the JSON parsing issue while maintaining the same meaning in Chinese.

Thank you for your understanding and for considering this fix.