### PR TITLE
Fix shutdown hang/crash on 26.2

### DIFF
--- a/common/src/main/java/dev/terminalmc/clientsort/client/interaction/InteractionManager.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/interaction/InteractionManager.java
@@ -42,7 +42,10 @@ public class InteractionManager {
     public static final Waiter TICK_WAITER = (TriggerType type) -> type == TriggerType.TICK;
 
     private static final ArrayDeque<InteractionEvent> eventQueue = new ArrayDeque<>();
-    private static final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+    private static final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(
+            1,
+            Thread.ofVirtual().name("clientsort-interaction-scheduler").factory()
+    );
 
     private static ScheduledFuture<?> tickFuture;
     private static Waiter waiter = null;


### PR DESCRIPTION
Since 26.2 the game times out and crashes waiting for the thread pool executor in InteractionManager to exit.

This PR make the executor use a virtual thread factory. Alternatively a platform daemon thread factory could be used if required.

```
The game crashed: client shutdown from post-main
Error: java.lang.Error: Watchdog (Client shutdown from post-main)
```