### PR TITLE
fix class policy map keys, ItemLocks bypass logic, slot index lookups, and result handler logging

### DIFF
--- a/common/src/main/java/dev/terminalmc/clientsort/client/compat/itemlocks/ItemLocksCompat.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/compat/itemlocks/ItemLocksCompat.java
@@ -90,7 +90,7 @@ public class ItemLocksCompat {
             Object isBypassResult = isBypassMethod.invoke(null);
             if (isBypassResult instanceof Boolean bypass) {
                 if (bypass)
-                    return true;
+                    return false;
             } else {
                 throw new ClassCastException();
             }

--- a/common/src/main/java/dev/terminalmc/clientsort/client/config/Config.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/config/Config.java
@@ -471,22 +471,20 @@ public class Config {
                     String className = cp.className();
                     if (ServerConfig.Options.classPolicyKeyUpgradeMap.containsKey(className))
                         className = ServerConfig.Options.classPolicyKeyUpgradeMap.get(className);
-                    validPolicies.put(
+                    ClassPolicy newCp = new ClassPolicy(
                             className,
-                            new ClassPolicy(
-                                    className,
-                                    cp.invTitle(),
-                                    cp.buttonOffset(),
-                                    cp.offsetFromSlot(),
-                                    Options.policyValidator.validate(cp.sortPolicy()),
-                                    Options.policyValidator.validate(cp.stackFillPolicy()),
-                                    Options.policyValidator.validate(cp.matchTransferPolicy()),
-                                    Options.policyValidator.validate(cp.transferPolicy()),
-                                    cp.autoOp(),
-                                    cp.autoOpOther(),
-                                    cp.ignoredSlots() == null ? new TreeSet<>() : cp.ignoredSlots()
-                            )
+                            cp.invTitle(),
+                            cp.buttonOffset(),
+                            cp.offsetFromSlot(),
+                            Options.policyValidator.validate(cp.sortPolicy()),
+                            Options.policyValidator.validate(cp.stackFillPolicy()),
+                            Options.policyValidator.validate(cp.matchTransferPolicy()),
+                            Options.policyValidator.validate(cp.transferPolicy()),
+                            cp.autoOp(),
+                            cp.autoOpOther(),
+                            cp.ignoredSlots() == null ? new TreeSet<>() : cp.ignoredSlots()
                     );
+                    validPolicies.put(newCp.getKey(), newCp);
                 }
             });
             // Sort the policies by key for better UX

--- a/common/src/main/java/dev/terminalmc/clientsort/client/gui/screen/edit/EditorScreen.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/gui/screen/edit/EditorScreen.java
@@ -248,17 +248,17 @@ public abstract class EditorScreen extends Screen {
                                                                 : Policy.KEYBIND
                                                                 : Policy.NONE,
                                                         buttons.get(1).operationAllowed
-                                                                ? buttons.getFirst().active
+                                                                ? buttons.get(1).active
                                                                 ? Policy.KEYBIND_BUTTON
                                                                 : Policy.KEYBIND
                                                                 : Policy.NONE,
                                                         buttons.get(2).operationAllowed
-                                                                ? buttons.getFirst().active
+                                                                ? buttons.get(2).active
                                                                 ? Policy.KEYBIND_BUTTON
                                                                 : Policy.KEYBIND
                                                                 : Policy.NONE,
                                                         buttons.get(3).operationAllowed
-                                                                ? buttons.getFirst().active
+                                                                ? buttons.get(3).active
                                                                 ? Policy.KEYBIND_BUTTON
                                                                 : Policy.KEYBIND
                                                                 : Policy.NONE,
@@ -330,17 +330,17 @@ public abstract class EditorScreen extends Screen {
                                                                     : Policy.KEYBIND
                                                                     : Policy.NONE,
                                                             buttons.get(1).operationAllowed
-                                                                    ? buttons.getFirst().active
+                                                                    ? buttons.get(1).active
                                                                     ? Policy.KEYBIND_BUTTON
                                                                     : Policy.KEYBIND
                                                                     : Policy.NONE,
                                                             buttons.get(2).operationAllowed
-                                                                    ? buttons.getFirst().active
+                                                                    ? buttons.get(2).active
                                                                     ? Policy.KEYBIND_BUTTON
                                                                     : Policy.KEYBIND
                                                                     : Policy.NONE,
                                                             buttons.get(3).operationAllowed
-                                                                    ? buttons.getFirst().active
+                                                                    ? buttons.get(3).active
                                                                     ? Policy.KEYBIND_BUTTON
                                                                     : Policy.KEYBIND
                                                                     : Policy.NONE,

--- a/common/src/main/java/dev/terminalmc/clientsort/client/inventory/helper/ContainerScreenHelper.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/inventory/helper/ContainerScreenHelper.java
@@ -195,7 +195,8 @@ public class ContainerScreenHelper<T extends AbstractContainerScreen<?>> {
 
             int slotIdx = ((ISlot) slot).clientsort$getIndexInContainer();
             if (slotIdx <= lastIdx || slot.container != lastContainer) {
-                slotGroups.add(currentGroup);
+                if (!currentGroup.isEmpty())
+                    slotGroups.add(currentGroup);
                 currentGroup = new ArrayList<>();
             }
             currentGroup.add(slot);

--- a/common/src/main/java/dev/terminalmc/clientsort/client/inventory/operator/SingleUseOperator.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/inventory/operator/SingleUseOperator.java
@@ -187,7 +187,7 @@ public abstract class SingleUseOperator {
                     continue;
             } else {
                 // Empty slot; check content-aware arbitrary item placement
-                if (!slot.container.canPlaceItem(slotId, testItem))
+                if (!slot.container.canPlaceItem(slotIdx, testItem))
                     continue;
             }
             // Ignore mod-locked slots

--- a/common/src/main/java/dev/terminalmc/clientsort/client/network/handler/StackFillResultHandler.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/network/handler/StackFillResultHandler.java
@@ -50,7 +50,7 @@ public class StackFillResultHandler {
             PayloadResult result = ResultHandlerUtil.interpretResult(
                     payload.result(),
                     payload.message(),
-                    CollectPayload.ID
+                    StackFillPayload.ID
             );
 
             if (onCompletion != null) {

--- a/common/src/main/java/dev/terminalmc/clientsort/client/network/handler/TransferResultHandler.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/client/network/handler/TransferResultHandler.java
@@ -50,7 +50,7 @@ public class TransferResultHandler {
             PayloadResult result = ResultHandlerUtil.interpretResult(
                     payload.result(),
                     payload.message(),
-                    CollectPayload.ID
+                    TransferPayload.ID
             );
 
             if (onCompletion != null) {

--- a/common/src/main/java/dev/terminalmc/clientsort/network/handler/validate/SchemaValidator.java
+++ b/common/src/main/java/dev/terminalmc/clientsort/network/handler/validate/SchemaValidator.java
@@ -134,7 +134,7 @@ public class SchemaValidator {
                     accessible = false;
             } else {
                 // Empty slot; check arbitrary item placement
-                if (!slot.container.canPlaceItem(slotId, testItem) || !slot.mayPlace(testItem))
+                if (!slot.container.canPlaceItem(slot.getContainerSlot(), testItem) || !slot.mayPlace(testItem))
                     accessible = false;
             }
             if (!accessible) {


### PR DESCRIPTION
- **Fixed class policy map key corruption in `Config.java`:**
  - *Why:* In `classPoliciesValidator`, policies were being put into `validPolicies` using only `className` as the key instead of `newCp.getKey()`. When a user created title-specific policies (which are keyed as `className/invTitle`), running validation on config save stripped the title component from the map key. This caused title-specific entries to collide and silently overwrite any other policy sharing that same class. I updated the validator to key entries by `newCp.getKey()`.

- **Fixed inverted ItemLocks bypass check in `ItemLocksCompat.java`:**
  - *Why:* `ItemLocksCompat.checkStatic` returned `true` (slot is locked) when `isBypassMethod` returned `true`. Holding the ItemLocks bypass key is meant to allow sorting on locked slots by treating them as unlocked. The previous logic inverted this, locking every slot in the inventory whenever the bypass key was held. I changed this to return `false` when bypass is active.

- **Fixed copy-pasted button active states in `EditorScreen.java`:**
  - *Why:* In both `splitPolicyClassButton` and `splitPolicyTitleButton`, the policy construction logic checked `buttons.get(1)`, `buttons.get(2)`, and `buttons.get(3)` for `operationAllowed`, but referenced `buttons.getFirst().active` for all four buttons when determining if button mode was active. As a result, individual visibility toggles on secondary buttons were ignored and overridden by the first button's state during policy splits. I updated each check to reference its corresponding button's active state.

- **Corrected payload IDs in `StackFillResultHandler.java` and `TransferResultHandler.java`:**
  - *Why:* Both handlers were passing `CollectPayload.ID` into `ResultHandlerUtil.interpretResult()`. This caused debug output and server failure warnings for stack fill and transfer operations to misidentify the payload as `clientsort:collect_c2s`. I updated each handler to pass `StackFillPayload.ID` and `TransferPayload.ID` respectively.

- **Passed container-local slot indices to `canPlaceItem` in `SingleUseOperator.java` and `SchemaValidator.java`:**
  - *Why:* `Container.canPlaceItem(int index, ItemStack stack)` expects an index relative to the target `Container`, but both files were passing `slotId` (the menu-wide slot index). In screens where menu slot IDs do not match container slot indices (such as player inventory slots inside an open container menu), this resulted in testing the wrong slot or throwing `IndexOutOfBoundsException` on containers with bounds checks. I updated `SingleUseOperator` to use `slotIdx` and `SchemaValidator` to use `slot.getContainerSlot()`.

- **Prevented leading empty groups in `ContainerScreenHelper.java`:**
  - *Why:* Because `lastIdx` initializes to `Integer.MAX_VALUE` and `lastContainer` to `null`, the group boundary condition `slotIdx <= lastIdx || slot.container != lastContainer` always evaluated to `true` on the first iteration. This caused an empty `List<Slot>` to be inserted as the first element of `slotGroups`. I added an `!currentGroup.isEmpty()` guard before appending.